### PR TITLE
Permit.io writing program

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
   > Technical tutorials and demos using Okta's products.
 
+- [Permit.io](https://io.permit.io/permit-content) - $400 per published article
+  >  Implement Permit.io into a demo application of your choice, create a piece of content about it, and get paid!
+
 - [PHP Architect](https://www.phparch.com/editorial/write-for-us/) - $175 per piece
   > Thought leadership and technical articles about PHP.
 


### PR DESCRIPTION
Added the Permit.io content creation program to the list.  Permit.io is an authorization-as-a-service provider that's quick and simple to implement. We’re looking for people who can implement Permit.io into their demo applications and create a piece of content about it!